### PR TITLE
attempting to conditionally push coverage report to codecov.io when p…

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -33,5 +33,6 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       with:
         name: Python ${{ matrix.python-version }} Codecov


### PR DESCRIPTION
Tox will fail the build if coverage drops below 100% so we aren't worried that untested code will slip through the cracks.  This is in an effort to keep codecov.io a bit cleaner and only have main branch coverage reports.  Not recommended for large open source projects but okay in this case.